### PR TITLE
Fix bug when trying to select already selected version.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ var listVersions = function() {
     var str = result.stdout.toString().replace(/\x1b[^m]*m|->/g, '');
     return str.split('\n')
     .map(function(line) { return line.trim(); })
-    .filter(function(line) { return line && !line.match(/current|->/); });
+    .filter(function(line) { return line && !line.match(/current|system/); });
   });
 };
 


### PR DESCRIPTION
Steps to reproduce bug (without this patch):

1 - nvm use 0.10.32
2 - .node-version with 0.10.32 (same as already selected version)
3 - cd to directory containing above .node-version
4 - error returned: avn could not activate node 0.10.32
