### PR TITLE
find nvm.sh path using $NVM_DIR

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var nvmCommand = function(command) {
   var deferred = q.defer();
   var stdout, stderr;
   var cmd = child_process.spawn('bash',
-    ['-c', 'source ~/.nvm/nvm.sh; nvm ' + command]);
+    ['-c', 'source $NVM_DIR/nvm.sh; nvm ' + command]);
 
   cmd.stdout.pipe(concat(function(data) {
     stdout = data;


### PR DESCRIPTION
`nvm.sh` wasn't installed for me in `~/.nvm` for me. This patch should make the script work no matter where the file is.
