### PR TITLE
Only update node version if current doesn't match

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,13 @@ var installedVersion = function(matching) {
  * @return {Promise}
  */
 var match = function(version) {
+  var currentVersion = versionNumber(process.version);
+  if (semver.satisfies(currentVersion, version)) {
+    return Promise.resolve({
+      version: currentVersion,
+      command: util.format('echo "Already using Node %s"', currentVersion)
+    });
+  }
   return Promise.resolve()
   .then(function() { return installedVersion(version); })
   .then(function(use) {


### PR DESCRIPTION
I am super sensitive about the performance of my terminal, having the terminal attempting to re-use the Node version I'm already using when I move around in my directory structure is maddening (300ms lag is OP).

This PR mods the `match` function to fast return if the current version of Node/IO.js satisfies the semver requirement.