### PR TITLE
[WIP] Alias support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var name = require('./package.json').name;
 var VERSION_REGEX = /(\w+)-(.+)/;
 
 /**
-* Get the system version of Node, if present. Otherwise, return N/A
+* Get the system version of Node, if present. Otherwise, return a rejected Promise.
 */
 var getSystemNode = function() {
   return new Promise(function(resolve, reject) {

--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ var match = function(version) {
       useVersion;
   })
   .then(function(useVersion) {
-    var use = (useVersion && useVersion.startsWith('system')) ?
+    var use = (useVersion && useVersion.indexOf('system') === 0) ?
       'system' : useVersion;
     var command = util.format('nvm use %s > /dev/null;', use);
     var result = { version: useVersion, command: command };

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ var name = require('./package.json').name;
 var VERSION_REGEX = /(\w+)-(.+)/;
 
 /**
-* Get the system version of Node, if present. Otherwise, return a rejected Promise.
+* Get the system version of Node, if present.
+* Otherwise, return a rejected Promise.
 */
 var getSystemNode = function() {
   return new Promise(function(resolve, reject) {
@@ -170,7 +171,7 @@ alias) to an installed version number (or N/A).
 */
 var resolveVersion = function(matching) {
   return Promise.resolve()
-    .then(function () { return nvmCommand('version "' + matching + '"'); })
+    .then(function() { return nvmCommand('version "' + matching + '"'); })
     .then(parseMatching);
 };
 
@@ -182,13 +183,13 @@ var resolveVersion = function(matching) {
  */
 var installedVersion = function(matching) {
   return Promise.resolve()
-  .then(function () {
+  .then(function() {
     return Promise.all([
       resolveVersion(matching),
-      listVersions()
+      listVersions(),
     ]);
   })
-  .spread(function (parsedVersion, versions) {
+  .spread(function(parsedVersion, versions) {
     var parsedMatching = parsedVersion !== 'N/A' ? parsedVersion : matching;
     return findVersion(versions, parsedMatching);
   });
@@ -203,7 +204,7 @@ var installedVersion = function(matching) {
 var match = function(version) {
   return Promise.resolve()
   .then(function() { return installedVersion(version); })
-  .then(function (useVersion) {
+  .then(function(useVersion) {
     return useVersion === 'system' ?
       getSystemNode()
         .then(parseMatching)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var getSystemNode = function() {
   return new Promise(function(resolve, reject) {
     var stdout, stderr;
     var cmd = child.spawn(process.env.SHELL,
-      ['-c', 'source $NVM_DIR/nvm.sh; nvm deactivate > /dev/null && node --version;']);
+      ['-c', 'source $NVM_DIR/nvm.sh; nvm use system > /dev/null && node --version;']);
 
     cmd.stdout.pipe(concat(function(data) {
       stdout = data;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var getSystemNode = function() {
   return new Promise(function(resolve, reject) {
     var stdout, stderr;
     var cmd = child.spawn(process.env.SHELL,
-      ['-c', 'source $NVM_DIR/nvm.sh; nvm use system > /dev/null && node --version;']);
+      ['-c', 'source $NVM_DIR/nvm.sh; nvm run --silent system --version;']);
 
     cmd.stdout.pipe(concat(function(data) {
       stdout = data;

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ var nvmCommand = function(command) {
       if (code === 0) { resolve({ stdout: stdout, stderr: stderr }); }
       else {
         reject(new Error(util.format('nvm exited with status: %d\n%s',
-          code, stdout.toString().trim() + stderr.toString().trim())));
+          code, String(stdout).trim() + String(stderr).trim())));
       }
     });
   });
@@ -76,7 +76,7 @@ var nvmCommand = function(command) {
  * @return {Array.<String>}
  */
 var parseVersions = function(output) {
-  var string = output.stdout.toString()
+  var string = String(output.stdout)
     .replace(/\x1b[^m]*m/g, '')
     .replace(/^->/gm, '');
   return string.split('\n')
@@ -160,7 +160,7 @@ var findVersion = function(versions, matching) {
 * @param {Promise} matching
 */
 var parseMatching = function(matching) {
-  return matching.stdout.toString().trim();
+  return String(matching.stdout).trim();
 };
 /**
 * Use nvm to resolve a version string (which could be a version number or an

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ var match = function(version) {
       getSystemNode()
         .then(parseMatching)
         .then(function(use) {
-          return 'system version of node: ' + use;
+          return 'system: ' + use;
         }) :
       useVersion;
   })

--- a/test/index.js
+++ b/test/index.js
@@ -11,21 +11,23 @@ describe('plugin', function() {
     var spawn = child.spawn;
 
     var getLTSVersion = 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"';
-    var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm version "system"';
+    var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm deactivate > /dev/null && node --version;';
+    var listNvmVersions = 'source $NVM_DIR/nvm.sh; nvm list';
 
     sinon.stub(child, 'spawn', function(cmd, args) {
       var versionMatch = args[1].match(/source \$NVM_DIR\/nvm\.sh; nvm version "(v*\d+[\.\d]*)"/);
+
       if (args[1] === getLTSVersion) {
         // Mock return for an aliased version
         return spawn('echo', ['v6.12.0']);
       } else if (args[1] === getSystemVersion) {
-        return spawn('echo', ['system']);
+        return spawn('echo', ['v0.12.7']);
       } else if (versionMatch) {
         // Mock return for a normal version numver
         var version = versionMatch[1];
         version = 'v' + version.replace('v', '');
         return spawn('echo', [version]);
-      } else if (args[1] === 'source $NVM_DIR/nvm.sh; nvm list') {
+      } else if (args[1] === listNvmVersions) {
         // Mock the version list command
         return spawn('echo', ['v0.7.12\n0.10.26\nv0.10.28\nv0.10.29\nv0.10.101\nv0.11.13\nv6.12.0']);
       } else {
@@ -152,8 +154,8 @@ describe('plugin', function() {
   it('finds system version', function (done) {
     plugin.match('system').then(function(result) {
       expect(result).to.eql({
-        version: 'v0.12.7',
-        command: 'nvm use system > /dev/null'
+        version: 'system version of node: v0.12.7',
+        command: 'nvm use system > /dev/null;'
       });
     }).done(done);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ var child = require('child_process');
 describe('plugin', function() {
 
   var getLTSVersion = 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"';
+  var getSystemLikeAlias = 'source $NVM_DIR/nvm.sh; nvm version "system-alias"';
   var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm run --silent system --version;';
   var listNvmVersions = 'source $NVM_DIR/nvm.sh; nvm list';
 
@@ -20,6 +21,8 @@ describe('plugin', function() {
       if (args[1] === getLTSVersion) {
         // Mock return for an aliased version
         return spawn('echo', ['v6.12.0']);
+      } else if (args[1] === getSystemLikeAlias) {
+        return spawn('echo', ['v6.9.5']);
       } else if (args[1] === getSystemVersion) {
         return spawn('echo', ['v0.12.7']);
       } else if (versionMatch) {
@@ -29,7 +32,7 @@ describe('plugin', function() {
         return spawn('echo', [version]);
       } else if (args[1] === listNvmVersions) {
         // Mock the version list command
-        return spawn('echo', ['v0.7.12\n0.10.26\nv0.10.28\nv0.10.29\nv0.10.101\nv0.11.13\nv6.12.0']);
+        return spawn('echo', ['v0.7.12\n0.10.26\nv0.10.28\nv0.10.29\nv0.10.101\nv0.11.13\nv6.9.5\nv6.12.0']);
       } else {
         // Assume all other commands are nvm version "<uninstalled_version>"
         return spawn('echo', ['N/A']);
@@ -156,6 +159,15 @@ describe('plugin', function() {
       expect(result).to.eql({
         version: 'system: v0.12.7',
         command: 'nvm use system > /dev/null;'
+      });
+    }).done(done);
+  });
+
+  it('differentiates between aliases containing "system" and the system node', function (done) {
+    plugin.match('system-alias').then(function(result) {
+      expect(result).to.eql({
+        version: 'v6.9.5',
+        command: 'nvm use v6.9.5 > /dev/null;'
       });
     }).done(done);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -7,12 +7,12 @@ var child = require('child_process');
 
 describe('plugin', function() {
 
+  var getLTSVersion = 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"';
+  var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm run --silent system --version;';
+  var listNvmVersions = 'source $NVM_DIR/nvm.sh; nvm list';
+
   beforeEach(function() {
     var spawn = child.spawn;
-
-    var getLTSVersion = 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"';
-    var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm run --silent system --version;';
-    var listNvmVersions = 'source $NVM_DIR/nvm.sh; nvm list';
 
     sinon.stub(child, 'spawn', function(cmd, args) {
       var versionMatch = args[1].match(/source \$NVM_DIR\/nvm\.sh; nvm version "(v*\d+[\.\d]*)"/);
@@ -142,7 +142,7 @@ describe('plugin', function() {
       .to.eql('iojs-v1.1.0');
   });
 
-  it('finds aliased versions', function (done) {
+  it('finds aliased versions', function(done) {
     plugin.match('lts/boron').then(function(result) {
       expect(result).to.eql({
         version: 'v6.12.0',
@@ -151,12 +151,46 @@ describe('plugin', function() {
     }).done(done);
   });
 
-  it('finds system version', function (done) {
+  it('finds system version', function(done) {
     plugin.match('system').then(function(result) {
       expect(result).to.eql({
         version: 'system: v0.12.7',
         command: 'nvm use system > /dev/null;'
       });
     }).done(done);
+  });
+
+  it('returns rejected promise if system node is not present', function(done) {
+    child.spawn.restore();
+
+    var spawn = child.spawn;
+
+    sinon.stub(child, 'spawn', function(cmd, args) {
+      var versionMatch = args[1].match(/source \$NVM_DIR\/nvm\.sh; nvm version "(v*\d+[\.\d]*)"/);
+
+      if (args[1] === getLTSVersion) {
+        // Mock return for an aliased version
+        return spawn('echo', ['v6.12.0']);
+      } else if (args[1] === getSystemVersion) {
+        return spawn(process.env.SHELL, ['1>&2', 'echo', '/Users/my_user/.nvm/nvm-exec: line 15: exec: system: not found']);
+      } else if (versionMatch) {
+        // Mock return for a normal version numver
+        var version = versionMatch[1];
+        version = 'v' + version.replace('v', '');
+        return spawn('echo', [version]);
+      } else if (args[1] === listNvmVersions) {
+        // Mock the version list command
+        return spawn('echo', ['v0.7.12\n0.10.26\nv0.10.28\nv0.10.29\nv0.10.101\nv0.11.13\nv6.12.0']);
+      } else {
+        // Assume all other commands are nvm version "<uninstalled_version>"
+        return spawn('echo', ['N/A']);
+      }
+    });
+    plugin.match('system').then(
+      function() {
+        throw new Error('Plugin should have rejected bad command.');
+      },
+      function(e) {expect(e).to.match(/.*Error: Could not find system version of node.*/);}
+    ).done(done);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -9,11 +9,17 @@ describe('plugin', function() {
 
   beforeEach(function() {
     var spawn = child.spawn;
+
+    var getLTSVersion = 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"';
+    var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm version "system"';
+
     sinon.stub(child, 'spawn', function(cmd, args) {
       var versionMatch = args[1].match(/source \$NVM_DIR\/nvm\.sh; nvm version "(v*\d+[\.\d]*)"/);
-      if (args[1] === 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"') {
+      if (args[1] === getLTSVersion) {
         // Mock return for an aliased version
         return spawn('echo', ['v6.12.0']);
+      } else if (args[1] === getSystemVersion) {
+        return spawn('echo', ['system']);
       } else if (versionMatch) {
         // Mock return for a normal version numver
         var version = versionMatch[1];
@@ -139,6 +145,15 @@ describe('plugin', function() {
       expect(result).to.eql({
         version: 'v6.12.0',
         command: 'nvm use v6.12.0 > /dev/null;'
+      });
+    }).done(done);
+  });
+
+  it('finds system version', function (done) {
+    plugin.match('system').then(function(result) {
+      expect(result).to.eql({
+        version: 'v0.12.7',
+        command: 'nvm use system > /dev/null'
       });
     }).done(done);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ describe('plugin', function() {
         return spawn('echo', ['v6.12.0'])
       } else if (versionMatch) {
         // Mock return for a normal version numver
-        var version = versionMatch[2];
+        var version = versionMatch[1];
         version = 'v' + version.replace('v', '');
         return spawn('echo', [version]);
       } else if (args[1] === 'source $NVM_DIR/nvm.sh; nvm list') {

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ describe('plugin', function() {
     var spawn = child.spawn;
 
     var getLTSVersion = 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"';
-    var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm deactivate > /dev/null && node --version;';
+    var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm use system > /dev/null && node --version;';
     var listNvmVersions = 'source $NVM_DIR/nvm.sh; nvm list';
 
     sinon.stub(child, 'spawn', function(cmd, args) {
@@ -154,7 +154,7 @@ describe('plugin', function() {
   it('finds system version', function (done) {
     plugin.match('system').then(function(result) {
       expect(result).to.eql({
-        version: 'system version of node: v0.12.7',
+        version: 'system: v0.12.7',
         command: 'nvm use system > /dev/null;'
       });
     }).done(done);

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ describe('plugin', function() {
     var spawn = child.spawn;
 
     var getLTSVersion = 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"';
-    var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm use system > /dev/null && node --version;';
+    var getSystemVersion = 'source $NVM_DIR/nvm.sh; nvm run --silent system --version;';
     var listNvmVersions = 'source $NVM_DIR/nvm.sh; nvm list';
 
     sinon.stub(child, 'spawn', function(cmd, args) {

--- a/test/index.js
+++ b/test/index.js
@@ -10,10 +10,10 @@ describe('plugin', function() {
   beforeEach(function() {
     var spawn = child.spawn;
     sinon.stub(child, 'spawn', function(cmd, args) {
-      var versionMatch = args[1].match(/source \$NVM_DIR\/nvm\.sh; nvm version "(v*\d+[\.\d]*)"/)
+      var versionMatch = args[1].match(/source \$NVM_DIR\/nvm\.sh; nvm version "(v*\d+[\.\d]*)"/);
       if (args[1] === 'source $NVM_DIR/nvm.sh; nvm version "lts/boron"') {
         // Mock return for an aliased version
-        return spawn('echo', ['v6.12.0'])
+        return spawn('echo', ['v6.12.0']);
       } else if (versionMatch) {
         // Mock return for a normal version numver
         var version = versionMatch[1];
@@ -24,7 +24,7 @@ describe('plugin', function() {
         return spawn('echo', ['v0.7.12\n0.10.26\nv0.10.28\nv0.10.29\nv0.10.101\nv0.11.13\nv6.12.0']);
       } else {
         // Assume all other commands are nvm version "<uninstalled_version>"
-        return spawn('echo', ['N/A'])
+        return spawn('echo', ['N/A']);
       }
 
     });
@@ -139,7 +139,7 @@ describe('plugin', function() {
       expect(result).to.eql({
         version: 'v6.12.0',
         command: 'nvm use v6.12.0 > /dev/null;'
-      })
-    }).done(done)
-  })
+      });
+    }).done(done);
+  });
 });


### PR DESCRIPTION
Adds support for aliased version names recognized by `nvm` including `lts/<release_name>`, `default`, `system`.

## Changes to Tests

Since we are now making more calls using `child.spawn` than just the `nvm list` command it was necessary to be more specific in how `sinon` mocked each all. The [`beforeEach` hook](https://github.com/duckontheweb/avn-nvm/blob/alias-support/test/index.js#L13-L36) now has logic to return different mocked responses based on the arguments.

Also added tests for alias and system support

## Resolving Aliases v. System Node

The `system` alias case had to be handled separately from other aliases, primarily due to the difference in the way `nvm` handles those two cases. For most aliases, we use `nvm version "<alias_name>"` to resolve a specific installed version number, then `nvm use <version_number>` to activate that version. However, with `system` we need to use `nvm use system` rather than the specific version the system node, since that version was not installed via `nvm` and therefore will throw an error. 

I wanted to be able to still log the actual version of node being used to keep things consistent with the logging for other version types, so I ended up propagating the value of `system` down through all of the methods that resolve a version and only find the actual version number [at the end](https://github.com/duckontheweb/avn-nvm/blob/alias-support/index.js#L208-L212) so that we can log out that info.

Addresses wbyoung/avn#43, wbyoung/avn#53

@wbyoung Let me know what suggestions/feedback you have.
