### PR TITLE
updated to not change version if already using acceptable version

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -51,14 +51,14 @@ describe('plugin', function() {
     .done(done);
   });
 
-  it('rejects versions already have active matching', function(done) {
+  it('rejects if server already using matching node version', function(done) {
     plugin.match('0.7').then(
       function() { throw new Error('Plugin should have rejected already active version.'); },
       function(e) { expect(e).to.match(/already using matching version/); })
       .done(done);
   });
 
-  it('rejects versions already have active matching', function(done) {
+  it('rejects if server already using matching node version', function(done) {
     plugin.match('0.7.12').then(
       function() { throw new Error('Plugin should have rejected already active version.'); },
       function(e) { expect(e).to.match(/already using matching version/); })


### PR DESCRIPTION
Kind of annoying when it auto-change version regardless of the node version I'm already on. 

This checks current node version with `nvm current`, and won't update version if current version is already acceptable for project.

tested:

- [x] updated unit tests and all pass.